### PR TITLE
Handle media paths without app context

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import re
 import os
 from functools import lru_cache
-from flask import Flask, render_template, url_for
+from flask import Flask, render_template
 
 app = Flask(__name__)
 
@@ -89,7 +89,7 @@ def parse_chat_file(file_path):
                     if media_match:
                         filename = media_match.group(1).strip()
                         print(f"Found Media: '{filename}'")
-                        media_path = url_for('static', filename=os.path.join(CHAT_EXPORT_DIR, filename))
+                        media_rel_path = os.path.join(CHAT_EXPORT_DIR, filename)
                         media_type = 'unknown'
                         if filename.lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.webp')):
                             media_type = 'image'
@@ -102,23 +102,23 @@ def parse_chat_file(file_path):
                         # Extract caption (text before/after the media tag)
                         # Replacing the found tag, then stripping.
                         caption = message_text.replace(media_match.group(0), '').strip()
-                        print(f"Media Type: {media_type}, Path: {media_path}, Caption: '{caption}'")
+                        print(f"Media Type: {media_type}, Relative Path: {media_rel_path}, Caption: '{caption}'")
 
                         messages.append({
                             'type': 'media',
                             'date': date,
                             'time': time,
                             'sender': sender,
-                            'media_path': media_path,
+                            'media_rel_path': media_rel_path,
                             'media_type': media_type,
                             'caption': caption
                         })
                         # Add to media gallery list if it's an image or video
                         if media_type in ['image', 'video']:
                             media_items.append({
-                                'media_path': media_path,
+                                'media_rel_path': media_rel_path,
                                 'media_type': media_type,
-                                'filename': filename # Keep filename for reference if needed
+                                'filename': filename  # Keep filename for reference if needed
                             })
                     elif message_text: # Only add if there's actual text content left
                         print("Added as Text Message.")

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,10 +36,10 @@
                             {# Handle Media #}
                             {% if message.type == 'media' %}
                                 {% if message.media_type == 'image' or message.media_type == 'sticker' %}
-                                    <img src="{{ message.media_path }}" alt="Image Attachment" class="chat-image" data-original-src="{{ message.media_path }}">
+                                    <img src="{{ url_for('static', filename=message.media_rel_path) }}" alt="Image Attachment" class="chat-image" data-original-src="{{ url_for('static', filename=message.media_rel_path) }}">
                                 {% elif message.media_type == 'video' %}
                                     <video controls class="chat-video">
-                                        <source src="{{ message.media_path }}" type="video/mp4"> {# Basic type, might need refinement #}
+                                        <source src="{{ url_for('static', filename=message.media_rel_path) }}" type="video/mp4"> {# Basic type, might need refinement #}
                                         Your browser does not support the video tag.
                                     </video>
                                 {% endif %}
@@ -73,10 +73,10 @@
             {% for item in media_items %}
                 <div class="gallery-item">
                     {% if item.media_type == 'image' %}
-                        <img src="{{ item.media_path }}" alt="Gallery Image" loading="lazy">
+                        <img src="{{ url_for('static', filename=item.media_rel_path) }}" alt="Gallery Image" loading="lazy">
                     {% elif item.media_type == 'video' %}
                         <video controls preload="metadata">
-                            <source src="{{ item.media_path }}#t=0.1" type="video/mp4"> <!-- #t=0.1 for thumbnail hint -->
+                            <source src="{{ url_for('static', filename=item.media_rel_path) }}#t=0.1" type="video/mp4"> <!-- #t=0.1 for thumbnail hint -->
                             Your browser does not support the video tag.
                         </video>
                     {% endif %}


### PR DESCRIPTION
## Summary
- handle media paths without `url_for` in `parse_chat_file`
- generate URLs for media in the template
- remove unused `url_for` import

## Testing
- `python -m py_compile app.py`